### PR TITLE
Add support for funding metadata key

### DIFF
--- a/_extensions/elsevier/partials/before-body.tex
+++ b/_extensions/elsevier/partials/before-body.tex
@@ -1,6 +1,13 @@
 
 \begin{frontmatter}
-\title{$title$$if(subtitle)$ \\\large{$subtitle$} $endif$}
+    
+\title{$title$$if(funding)$\tnoteref{funding}$endif$$if(subtitle)$\\\large{$subtitle$} $endif$}
+$if(funding)$
+\tnotetext[funding]{$for(funding)$$it.statement$$endfor$}
+$endif$
+
+\tnotetext[funding]{$for(funding)$$it.statement$$endfor$}
+
 $for(by-author)$\author[$for(by-author.affiliations)$$it.number$$sep$,$endfor$]{$by-author.name.literal$%
 $if(by-author.attributes.corresponding)$\corref{cor1}$endif$%
 $if(by-author.note.text)$\fnref{fn$by-author.note.number$}$endif$}

--- a/_extensions/elsevier/partials/before-body.tex
+++ b/_extensions/elsevier/partials/before-body.tex
@@ -6,8 +6,6 @@ $if(funding)$
 \tnotetext[funding]{$for(funding)$$it.statement$$endfor$}
 $endif$
 
-\tnotetext[funding]{$for(funding)$$it.statement$$endfor$}
-
 $for(by-author)$\author[$for(by-author.affiliations)$$it.number$$sep$,$endfor$]{$by-author.name.literal$%
 $if(by-author.attributes.corresponding)$\corref{cor1}$endif$%
 $if(by-author.note.text)$\fnref{fn$by-author.note.number$}$endif$}


### PR DESCRIPTION
I have added basic support for `funding` as indicated at https://assets.ctfassets.net/o78em1y1w4i4/3ro3yQff1q67JHmLi1sAqV/1348e3852f277867230fc4b84a801734/elsdoc-1.pdf.

It can be used in the following way:
```
---
...
funding:
     statement: This work is supported by AAA [aaa name]
...
---
```

However, I haven't found any elegant option to support:
```
---
...
funding: This work is supported by AAA [aaa name]
...
---
```
My suspicion is that the `funding` keyword is not well parsed in quarto, but I'm not sure.

Is it enough or should it be improved?

