### PR TITLE
Add missing bibliography style files for elsarticle v3.4c

### DIFF
--- a/_extensions/elsevier/bib/elsarticle-harv.bst
+++ b/_extensions/elsevier/bib/elsarticle-harv.bst
@@ -1,19 +1,19 @@
 %%
 %% This is file `elsarticle-harv.bst'  (Version 2.1),
 %% 
-%% Copyright 2009-2020 Elsevier Ltd
+%% Copyright 2009-2025 Elsevier Ltd
 %% 
 %% This file is part of the 'Elsarticle Bundle'.
 %% ---------------------------------------------
 %% 
 %% It may be distributed under the conditions of the LaTeX Project Public
-%% License, either version 1.2 of this license or (at your option) any
+%% License, either version 1.3 of this license or (at your option) any
 %% later version.  The latest version of this license is in
 %%    http://www.latex-project.org/lppl.txt
-%% and version 1.2 or later is part of all distributions of LaTeX
+%% and version 1.3 or later is part of all distributions of LaTeX
 %% version 1999/12/01 or later.
 %%
-%% $Id: elsarticle-harv.bst 194 2020-11-23 11:29:27Z rishi $
+%% $Id: elsarticle-harv.bst 271 2025-01-09 17:33:11Z rishi $
 %%
 %% $URL: https://lenova.river-valley.com/svn/elsarticle/trunk/elsarticle-harv.bst $
 %% 

--- a/_extensions/elsevier/bib/elsarticle-num-names.bst
+++ b/_extensions/elsevier/bib/elsarticle-num-names.bst
@@ -1,19 +1,19 @@
 %%
 %% This is file `elsarticle-num-names.bst'  (Version 2.1),
 %% 
-%% Copyright 2009-2020 Elsevier Ltd
+%% Copyright 2009-2025 Elsevier Ltd
 %% 
 %% This file is part of the 'Elsarticle Bundle'.
 %% ---------------------------------------------
 %% 
 %% It may be distributed under the conditions of the LaTeX Project Public
-%% License, either version 1.2 of this license or (at your option) any
+%% License, either version 1.3 of this license or (at your option) any
 %% later version.  The latest version of this license is in
 %%    http://www.latex-project.org/lppl.txt
-%% and version 1.2 or later is part of all distributions of LaTeX
+%% and version 1.3 or later is part of all distributions of LaTeX
 %% version 1999/12/01 or later.
 %%
-%% $Id: elsarticle-num-names.bst 194 2020-11-23 11:29:27Z rishi $
+%% $Id: elsarticle-num-names.bst 272 2025-01-09 17:36:26Z rishi $
 %%
 %% $URL: https://lenova.river-valley.com/svn/elsarticle/trunk/elsarticle-num-names.bst $
 %%

--- a/_extensions/elsevier/bib/elsarticle-num.bst
+++ b/_extensions/elsevier/bib/elsarticle-num.bst
@@ -1,20 +1,20 @@
 %%
 %% This is file `elsarticle-num.bst' (Version 2.1),
 %% 
-%% Copyright 2007-2020 Elsevier Ltd
+%% Copyright 2007-2025 Elsevier Ltd
 %% 
 %% This file is part of the 'Elsarticle Bundle'.
 %% ---------------------------------------------
 %% 
 %% It may be distributed under the conditions of the LaTeX Project Public
-%% License, either version 1.2 of this license or (at your option) any
+%% License, either version 1.3 of this license or (at your option) any
 %% later version.  The latest version of this license is in
 %%    http://www.latex-project.org/lppl.txt
-%% and version 1.2 or later is part of all distributions of LaTeX
+%% and version 1.3 or later is part of all distributions of LaTeX
 %% version 1999/12/01 or later.
 %% 
 %% 
-%% $Id: elsarticle-num.bst 194 2020-11-23 11:29:27Z rishi $
+%% $Id: elsarticle-num.bst 272 2025-01-09 17:36:26Z rishi $
 %% 
 %% $URL: https://lenova.river-valley.com/svn/elsarticle/trunk/elsarticle-num.bst $
 %%


### PR DESCRIPTION
Adds the missing bibliography style files to complete the elsarticle v3.4c update from PR #38.

## Files Added

- `_extensions/elsevier/bib/elsarticle-harv.bst`
- `_extensions/elsevier/bib/elsarticle-num.bst`
- `_extensions/elsevier/bib/elsarticle-num-names.bst`

These bibliography style files are part of the elsarticle CTAN bundle and should be updated together with elsarticle.cls.

Builds on #38 by @tuyenhn

Source: https://ctan.org/tex-archive/macros/latex/contrib/elsarticle